### PR TITLE
Fixing issues.  Cleint assertion creation required to be async functi…

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -82,7 +82,9 @@ module.exports = class Client {
             'Content-Type': 'application/x-www-form-urlencoded',
           },
         }).post('', querystring.stringify(assertion)).then((response) => {
-          const json = ((typeof response.data) == 'string') ? JSON.parse(response.data): response.data;
+          const json = ((typeof response.data) === 'string') ?
+            JSON.parse(response.data) :
+            response.data;
           this.setBearerToken(json.access_token);
         }).catch((e) => {
           console.error(e);

--- a/src/Client.js
+++ b/src/Client.js
@@ -24,7 +24,6 @@ module.exports = class Client {
   setBearerToken(token) {
     this.apiGateway.defaults.headers.common['Authorization'] =
       `Bearer ${token}`;
-    console.log(this.apiGateway.defaults.headers.common['Authorization']);
   }
 
   getTokenUrl() {
@@ -33,7 +32,7 @@ module.exports = class Client {
     ).then((r) => r.data.token_endpoint);
   }
 
-  async generateClientAssetion(tokenEndpoint, jti) {
+  async generateClientAssertion(tokenEndpoint, jti) {
     const options = {
       compact: true,
       alg: 'RS384',
@@ -74,7 +73,7 @@ module.exports = class Client {
         rejectUnauthorized: rejectUnauthorized, // Turn off ssl verification
       });
 
-      this.generateClientAssetion(tokenEndpoint).then((assertion) => {
+      return this.generateClientAssertion(tokenEndpoint).then((assertion) => {
         return axios.create({
           httpsAgent,
           baseURL: tokenEndpoint,
@@ -83,7 +82,7 @@ module.exports = class Client {
             'Content-Type': 'application/x-www-form-urlencoded',
           },
         }).post('', querystring.stringify(assertion)).then((response) => {
-          const json = JSON.parse(response.data);
+          const json = ((typeof response.data) == 'string') ? JSON.parse(response.data): response.data;
           this.setBearerToken(json.access_token);
         }).catch((e) => {
           console.error(e);

--- a/src/Client.js
+++ b/src/Client.js
@@ -1,6 +1,7 @@
 const https = require('https');
 const axios = require('axios');
 const uuidv4 = require('uuid/v4');
+const querystring = require('querystring');
 const {
   JWS,
 } = require('node-jose');
@@ -14,7 +15,6 @@ module.exports = class Client {
     this.config = config;
     this.jwk = this.config.jwk;
     this.clientId = this.config.clientId;
-
     this.apiGateway = axios.create({
       baseURL: this.config.baseURL,
       timeout: this.config.timeout,
@@ -24,7 +24,6 @@ module.exports = class Client {
   setBearerToken(token) {
     this.apiGateway.defaults.headers.common['Authorization'] =
       `Bearer ${token}`;
-
     console.log(this.apiGateway.defaults.headers.common['Authorization']);
   }
 
@@ -34,8 +33,7 @@ module.exports = class Client {
     ).then((r) => r.data.token_endpoint);
   }
 
-
-  generateClientAssertion(tokenEndpoint, jti) {
+  async generateClientAssetion(tokenEndpoint, jti) {
     const options = {
       compact: true,
       alg: 'RS384',
@@ -48,12 +46,12 @@ module.exports = class Client {
     const content = JSON.stringify({
       iss: this.clientId,
       sub: this.clientId,
-      aud: tokenEndpoint,
+      aud: this.config.aud || tokenEndpoint,
       exp: Math.floor(Date.now() / 1000) + 300,
       jti: jti || uuidv4(),
     });
 
-    const assertion = JWS.createSign(
+    const assertion = await JWS.createSign(
         options,
         this.jwk,
     ).update(content).final();
@@ -73,24 +71,29 @@ module.exports = class Client {
         rejectUnauthorized = true;
       }
       const httpsAgent = new https.Agent({
-        rejectUnauthorized, // Turn off ssl verification
+        rejectUnauthorized: rejectUnauthorized, // Turn off ssl verification
       });
-      const assertion = this.generateClientAssertion(tokenEndpoint);
-      return axios.create({
-        httpsAgent,
-        baseURL: tokenEndpoint,
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-      }).post('', assertion).then((response) => {
-        this.setBearerToken(response.data.access_token);
+
+      this.generateClientAssetion(tokenEndpoint).then((assertion) => {
+        return axios.create({
+          httpsAgent,
+          baseURL: tokenEndpoint,
+          headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+        }).post('', querystring.stringify(assertion)).then((response) => {
+          const json = JSON.parse(response.data);
+          this.setBearerToken(json.access_token);
+        }).catch((e) => {
+          console.error(e);
+        });
       });
     });
   }
 
   processMessage(message) {
     // TODO: hook some local validation in here
-    return this.apiGateway.post('/R4/$process-message', message);
+    return this.apiGateway.post('/$process-message', message);
   };
 };

--- a/src/__test__/client.test.js
+++ b/src/__test__/client.test.js
@@ -15,7 +15,7 @@ describe('Client', () => {
     const scope = nock('http://localhost')
         .get('/.well-known/smart-configuration')
         .reply(200, wellKnown);
-    scope.post('/token').reply(200, "{\"access_token\": \"FAKE_BEARER_TOKEN\"}");
+    scope.post('/token').reply(200, '{\"access_token\": \"FAKE_BEARER_TOKEN\"}');
     scope.post('/$process-message').reply(200, fakeResponse);
   });
 

--- a/src/__test__/client.test.js
+++ b/src/__test__/client.test.js
@@ -15,8 +15,8 @@ describe('Client', () => {
     const scope = nock('http://localhost')
         .get('/.well-known/smart-configuration')
         .reply(200, wellKnown);
-    scope.post('/token').reply(200, {'access_token': 'FAKE_BEARER_TOKEN'});
-    scope.post('/R4/$process-message').reply(200, fakeResponse);
+    scope.post('/token').reply(200, "{\"access_token\": \"FAKE_BEARER_TOKEN\"}");
+    scope.post('/$process-message').reply(200, fakeResponse);
   });
 
 
@@ -36,16 +36,17 @@ describe('Client', () => {
     };
 
     const client = new Client(config);
-    const assertion = client.generateClientAssertion(wellKnown.token_endpoint, 1);
-    expect(assertion);
-    expect(assertion.client_assertion_type);
-    expect(assertion.client_assertion_type).toEqual(
-        expectedAssertion.client_assertion_type,
-    );
-    expect(assertion.grant_type).toEqual(expectedAssertion.grant_type);
-    expect(assertion.scope).toEqual(expectedAssertion.scope);
+    client.generateClientAssertion(wellKnown.token_endpoint, 1).then((assertion) => {
+      expect(assertion);
+      expect(assertion.client_assertion_type);
+      expect(assertion.client_assertion_type).toEqual(
+          expectedAssertion.client_assertion_type,
+      );
+      expect(assertion.grant_type).toEqual(expectedAssertion.grant_type);
+      expect(assertion.scope).toEqual(expectedAssertion.scope);
 
-    done();
+      done();
+    });
   });
 
   it('Can make authorization request for token with signed assertion', (done) => {


### PR DESCRIPTION
…on to allow for the signature to be created.  This also required restructuring the authorization method to deal with the new promise return value.  Added ability to configure the aud parameter of the jwt, currently keycloak is expecting the base relm url instead of the token url. Properly formated authorization request with urlencoded body