### PR TITLE
Add error details

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,11 @@ try {
               if (file.endsWith('.json')) {
                 client.processMessage(fileContent)
                     .then(() => console.log(`${file} - Success!`))
-                    .catch((e) => console.error(`${file} - ${e.message}`));
+                    .catch((e) => {
+                      const violation = JSON.parse(e.response.data.errorMessage);
+                      const violationText = violation.issue[0].details.text;
+                      console.error(`${file} - ${e.message} - ${violationText}`);
+                    });
               }
             }
           }


### PR DESCRIPTION
This adds details to the message we log when there is an error processing the message. The field that `violationText` looks at is set by us before we return any error, so we know that the field exists and has the appropriate text in it.

I didn't update any message in the success case because I didn't feel that there was any additional information that would be helpful there.