### PR TITLE
Update error handling to deal with new response format

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ try {
                     .then(() => console.log(`${file} - Success!`))
                     .catch((e) => {
                       const violation = JSON.parse(e.response.data.errorMessage);
-                      const violationText = violation.issue[0].details.text;
+                      const violationText = violation.entry[1].resource.issue.details.text;
                       console.error(`${file} - ${e.message} - ${violationText}`);
                     });
               }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-messaging-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A command-line interface that posts FHIR Messages from a file system to the ICAREdata API",
   "main": "src/Client.js",
   "repository": {


### PR DESCRIPTION
After changes were made to the ICAREdata Platform response format, we needed to update how we parse errors from the FHIR-messaging-client perspective. This deals with that and introduces a new version number so that we can update the ICARE-extraction-client appropriately.