### PR TITLE
Remove error logging, consistently throw errors to be handled

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,6 @@
     },
     "rules": {
         "require-jsdoc": 0,
-        "max-len": [2, 100, 2]
+        "max-len": [2, 120, 2]
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,6 @@
     },
     "rules": {
         "require-jsdoc": 0,
-        "max-len": [2, 90, 2]
+        "max-len": [2, 100, 2]
     }
 }

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ try {
   client.canSendMessage()
       .then((r) => {
         if (!r) {
-          console.log(`The server does not provide the 'system/$process-message' scope.`);
+          console.error(`The server does not provide the 'system/$process-message' scope.`);
           return;
         }
         client.authorize().then(() => {
@@ -53,10 +53,10 @@ try {
               }
             }
           }
-        }).catch((e) => console.log(e));
+        }).catch((e) => console.error(e.message));
       })
-      .catch((e) => console.log(e));
+      .catch((e) => console.error(e.message));
 } catch (e) {
-  console.error(e);
+  console.error(e.message);
   program.help();
 };

--- a/src/Client.js
+++ b/src/Client.js
@@ -22,31 +22,30 @@ module.exports = class Client {
 
   async canSendMessage() {
     if (!this.config) {
-      throw new Error(`No config provided for client.`);
+      throw new Error(`FHIRMessagingClient config provided for client.`);
     }
 
     if (!this.config.baseURL) {
-      throw new Error(`The config does not contain a 'baseURL' field.`);
+      throw new Error(`FHIRMessagingClient config does not contain a 'baseURL' field.`);
     }
 
     if (!this.config.clientId) {
-      throw new Error(`The config does not contain a 'clientId' field.`);
+      throw new Error(`FHIRMessagingClient config does not contain a 'clientId' field.`);
     }
 
     if (!this.config.aud) {
-      throw new Error(`The config does not contain an 'aud' field.`);
+      throw new Error(`FHIRMessagingClient config does not contain an 'aud' field.`);
     }
 
     if (!(this.config.jwk || (this.config.pkcs12 && this.config.pkcs12Pass))) {
       throw new Error(
-          `The config does not contain a 'jwk' field or a 'pkcs12' and 'pkcs12Pass' field.`,
+          `FHIRMessagingClient config does not contain a 'jwk' field or a 'pkcs12' and 'pkcs12Pass' field.`,
       );
     }
 
     const smartConfiguration =
       await this.apiGateway.get('/.well-known/smart-configuration')
-          .then((r) => r)
-          .catch((e) => e);
+          .then((r) => r);
 
     if (smartConfiguration && smartConfiguration.data) {
       const scopes = smartConfiguration.data.scopes_supported;

--- a/src/Client.js
+++ b/src/Client.js
@@ -21,10 +21,32 @@ module.exports = class Client {
   }
 
   async canSendMessage() {
+    if (!this.config) {
+      throw new Error(`No config provided for client.`);
+    }
+
+    if (!this.config.baseURL) {
+      throw new Error(`The config does not contain a 'baseURL' field.`);
+    }
+
+    if (!this.config.clientId) {
+      throw new Error(`The config does not contain a 'clientId' field.`);
+    }
+
+    if (!this.config.aud) {
+      throw new Error(`The config does not contain an 'aud' field.`);
+    }
+
+    if (!(this.config.jwk || (this.config.pkcs12 && this.config.pkcs12Pass))) {
+      throw new Error(
+          `The config does not contain a 'jwk' field or a 'pkcs12' and 'pkcs12Pass' field.`,
+      );
+    }
+
     const smartConfiguration =
       await this.apiGateway.get('/.well-known/smart-configuration')
           .then((r) => r)
-          .catch((e) => console.log(e));
+          .catch((e) => e);
 
     if (smartConfiguration && smartConfiguration.data) {
       const scopes = smartConfiguration.data.scopes_supported;
@@ -112,8 +134,6 @@ module.exports = class Client {
             JSON.parse(response.data) :
             response.data;
           this.setBearerToken(json.access_token);
-        }).catch((e) => {
-          console.error(e);
         });
       });
     });

--- a/src/__test__/client.test.js
+++ b/src/__test__/client.test.js
@@ -1,5 +1,6 @@
 const Client = require('../client');
 const config = require('./config.json');
+const configPkcs12 = require('./configPkcs12.json');
 const nock = require('nock');
 const pkcs12JWK = require('./pkcs12JWK.json');
 const wellKnown = {
@@ -37,8 +38,7 @@ describe('Client', () => {
   });
 
   it('Can generate jwk from pkcs12 file', (done) => {
-    const client = new Client({pkcs12: './src/__test__/keystore.p12',
-      pkcs12Pass: 'test'});
+    const client = new Client(configPkcs12);
     client.getJWK().then((jwk) => {
       expect(jwk).toEqual(pkcs12JWK);
       done();

--- a/src/__test__/config.json
+++ b/src/__test__/config.json
@@ -1,6 +1,7 @@
 {
   "baseURL" : "http://localhost",
-  "client_id": "someid",
+  "clientId": "someid",
+  "aud": "someaud",
   "jwk": {
     "kty": "RSA",
     "kid": "57540f2e-d3f7-4cbc-b292-b04b510de634",

--- a/src/__test__/configPkcs12.json
+++ b/src/__test__/configPkcs12.json
@@ -1,0 +1,7 @@
+{
+  "baseURL" : "http://localhost",
+  "clientId": "someid",
+  "aud": "someaud",
+  "pkcs12": "./src/__test__/keystore.p12",
+  "pkcs12Pass": "test"
+}


### PR DESCRIPTION
Changes the client to consistently throw errors to be handled. Previously, there was a mixture of errors being thrown and log statements. This now makes it consistently throw errors. Additionally, adds more checks for error conditions to throw accurate error messages.

The implication here is that the repositories using this as a dependency will have to catch errors. This seems to have already been the assumption since we had to do so previously, but now we can ensure that this is what we need to do consistently.